### PR TITLE
fix: action message

### DIFF
--- a/src/github/action.js
+++ b/src/github/action.js
@@ -15,9 +15,8 @@ async function getVulnerabilities(repo, owner, token) {
 async function issuesMessage(repoInfo, vulnerabilityIssues) {
 	let issuesList = '';
 	await vulnerabilityIssues.forEach((issue) => {
-		const pr = _.find(repoInfo.pullRequests.nodes, (node) =>
-			node.title.match(issue.securityVulnerability.package.name),
-		);
+		const package = new RegExp(`.*bump\s${issue.securityVulnerability.package.name}\s.*`);
+		const pr = _.find(repoInfo.pullRequests.nodes, (node) => node.title.match(package));
 		issuesList = `${issuesList}
 - [${issue.securityVulnerability.package.name}](${issue.securityVulnerability.advisory.notificationsPermalink}) (${
 			issue.securityVulnerability.severity

--- a/src/github/action.js
+++ b/src/github/action.js
@@ -17,10 +17,12 @@ async function issuesMessage(repoInfo, vulnerabilityIssues) {
 	await vulnerabilityIssues.forEach((issue) => {
 		const package = new RegExp(`.*bump\s${issue.securityVulnerability.package.name}\s.*`);
 		const pr = _.find(repoInfo.pullRequests.nodes, (node) => node.title.match(package));
-		issuesList = `${issuesList}
+		if (!issuesList.includes(pr.url)) {
+			issuesList = `${issuesList}
 - [${issue.securityVulnerability.package.name}](${issue.securityVulnerability.advisory.notificationsPermalink}) (${
-			issue.securityVulnerability.severity
-		} severity). PR created by dependabot: ${pr ? pr.url : 'none'}`;
+				issue.securityVulnerability.severity
+			} severity). PR created by dependabot: ${pr ? pr.url : 'none'}`;
+		}
 	});
 	return issuesList;
 }


### PR DESCRIPTION
- More specific match for deps PR to avoid cases where different dependencies have similar names, e.g.
![Screenshot from 2021-05-10 13-58-07](https://user-images.githubusercontent.com/45420854/117670898-d5cb9880-b197-11eb-9464-d023d2ba720e.png)
- don't duplicate PR reference on the message if the same PR was already mentioned.