### PR TITLE
feat: sort vulnerability issues by severity

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23127,7 +23127,17 @@ async function getVulnerabilities(repo, owner, token) {
 
 async function issuesMessage(repoInfo, vulnerabilityIssues) {
 	let issuesList = '';
-	await vulnerabilityIssues.forEach((issue) => {
+	const vulnerabilityIssuesSorted = _.sortBy(vulnerabilityIssues, (issue) => {
+		const rank = {
+			CRITICAL: 1,
+			HIGH: 2,
+			LOW: 3,
+			MODERATE: 4,
+		};
+
+		return rank[issue.securityVulnerability.severity];
+	});
+	await vulnerabilityIssuesSorted.forEach((issue) => {
 		const packageName = new RegExp(`.*bump\\s${issue.securityVulnerability.package.name}\\s.*`);
 		const pr = _.find(repoInfo.pullRequests.nodes, (node) => node.title.match(packageName));
 		if (pr && pr.url && !issuesList.includes(pr.url)) {

--- a/src/github/action.js
+++ b/src/github/action.js
@@ -14,7 +14,17 @@ async function getVulnerabilities(repo, owner, token) {
 
 async function issuesMessage(repoInfo, vulnerabilityIssues) {
 	let issuesList = '';
-	await vulnerabilityIssues.forEach((issue) => {
+	const vulnerabilityIssuesSorted = _.sortBy(vulnerabilityIssues, (issue) => {
+		const rank = {
+			CRITICAL: 1,
+			HIGH: 2,
+			LOW: 3,
+			MODERATE: 4,
+		};
+
+		return rank[issue.securityVulnerability.severity];
+	});
+	await vulnerabilityIssuesSorted.forEach((issue) => {
 		const packageName = new RegExp(`.*bump\\s${issue.securityVulnerability.package.name}\\s.*`);
 		const pr = _.find(repoInfo.pullRequests.nodes, (node) => node.title.match(packageName));
 		if (pr && pr.url && !issuesList.includes(pr.url)) {


### PR DESCRIPTION
Sort vulnerability issues by severity and put critical ones on the message first.

The list of available severity values is taken [here](https://docs.github.com/en/graphql/reference/enums#securityadvisoryseverity).