### PR TITLE
fix: ignore dismissed issues

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41,13 +41,13 @@ async function run() {
 		const repoDefaultBranch = ctx.getDefaultBranch(context);
 		const repoInfo = await action.getVulnerabilities(repoName, repoOwner, process.env.GITHUB_TOKEN || ghPat);
 		const repoPRs = repoInfo.pullRequests.nodes;
-		const [prInfo] = await _.filter(repoPRs, (node) => node.number === pullRequestNumber);
+		const [prInfo] = _.filter(repoPRs, (node) => node.number === pullRequestNumber);
 		const prCommits = prInfo.commits.nodes;
-		const repoVulnerabilityAlerts = await _.filter(repoInfo.vulnerabilityAlerts.nodes, (node) => !node.dismissedAt);
-		const criticalIssues = await _.filter(repoVulnerabilityAlerts, (node) =>
+		const repoVulnerabilityAlerts = _.filter(repoInfo.vulnerabilityAlerts.nodes, (node) => !node.dismissedAt);
+		const criticalIssues = _.filter(repoVulnerabilityAlerts, (node) =>
 			node.securityVulnerability.severity.match(/CRITICAL|HIGH/),
 		);
-		const otherIssues = await _.filter(
+		const otherIssues = _.filter(
 			repoVulnerabilityAlerts,
 			(node) => !node.securityVulnerability.severity.match(/CRITICAL|HIGH/),
 		);

--- a/dist/index.js
+++ b/dist/index.js
@@ -43,7 +43,7 @@ async function run() {
 		const repoPRs = repoInfo.pullRequests.nodes;
 		const [prInfo] = await _.filter(repoPRs, (node) => node.number === pullRequestNumber);
 		const prCommits = prInfo.commits.nodes;
-		const repoVulnerabilityAlerts = repoInfo.vulnerabilityAlerts.nodes;
+		const repoVulnerabilityAlerts = await _.filter(repoInfo.vulnerabilityAlerts.nodes, (node) => !node.dismissedAt);
 		const criticalIssues = await _.filter(repoVulnerabilityAlerts, (node) =>
 			node.securityVulnerability.severity.match(/CRITICAL|HIGH/),
 		);
@@ -24708,6 +24708,7 @@ module.exports = {
       }
       vulnerabilityAlerts(first: 100) {
         nodes {
+          dismissedAt
           securityVulnerability {
                       severity
                       advisory {

--- a/index.js
+++ b/index.js
@@ -35,13 +35,13 @@ async function run() {
 		const repoDefaultBranch = ctx.getDefaultBranch(context);
 		const repoInfo = await action.getVulnerabilities(repoName, repoOwner, process.env.GITHUB_TOKEN || ghPat);
 		const repoPRs = repoInfo.pullRequests.nodes;
-		const [prInfo] = await _.filter(repoPRs, (node) => node.number === pullRequestNumber);
+		const [prInfo] = _.filter(repoPRs, (node) => node.number === pullRequestNumber);
 		const prCommits = prInfo.commits.nodes;
-		const repoVulnerabilityAlerts = await _.filter(repoInfo.vulnerabilityAlerts.nodes, (node) => !node.dismissedAt);
-		const criticalIssues = await _.filter(repoVulnerabilityAlerts, (node) =>
+		const repoVulnerabilityAlerts = _.filter(repoInfo.vulnerabilityAlerts.nodes, (node) => !node.dismissedAt);
+		const criticalIssues = _.filter(repoVulnerabilityAlerts, (node) =>
 			node.securityVulnerability.severity.match(/CRITICAL|HIGH/),
 		);
-		const otherIssues = await _.filter(
+		const otherIssues = _.filter(
 			repoVulnerabilityAlerts,
 			(node) => !node.securityVulnerability.severity.match(/CRITICAL|HIGH/),
 		);

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ async function run() {
 		const repoPRs = repoInfo.pullRequests.nodes;
 		const [prInfo] = await _.filter(repoPRs, (node) => node.number === pullRequestNumber);
 		const prCommits = prInfo.commits.nodes;
-		const repoVulnerabilityAlerts = repoInfo.vulnerabilityAlerts.nodes;
+		const repoVulnerabilityAlerts = await _.filter(repoInfo.vulnerabilityAlerts.nodes, (node) => !node.dismissedAt);
 		const criticalIssues = await _.filter(repoVulnerabilityAlerts, (node) =>
 			node.securityVulnerability.severity.match(/CRITICAL|HIGH/),
 		);

--- a/src/graphQL.js
+++ b/src/graphQL.js
@@ -18,6 +18,7 @@ module.exports = {
       }
       vulnerabilityAlerts(first: 100) {
         nodes {
+          dismissedAt
           securityVulnerability {
                       severity
                       advisory {

--- a/test/unit/fixtures/graphql/oneHighIssue.js
+++ b/test/unit/fixtures/graphql/oneHighIssue.js
@@ -22,6 +22,7 @@ module.exports = {
 			vulnerabilityAlerts: {
 				nodes: [
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {

--- a/test/unit/fixtures/graphql/oneHighIssueWithFix.js
+++ b/test/unit/fixtures/graphql/oneHighIssueWithFix.js
@@ -22,6 +22,7 @@ module.exports = {
 			vulnerabilityAlerts: {
 				nodes: [
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {

--- a/test/unit/fixtures/graphql/onlyMinorIssues.js
+++ b/test/unit/fixtures/graphql/onlyMinorIssues.js
@@ -22,6 +22,7 @@ module.exports = {
 			vulnerabilityAlerts: {
 				nodes: [
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'LOW',
 							advisory: {
@@ -38,6 +39,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: 'test',
 						securityVulnerability: {
 							severity: 'LOW',
 							advisory: {
@@ -54,6 +56,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'LOW',
 							advisory: {

--- a/test/unit/fixtures/graphql/repoInfo.js
+++ b/test/unit/fixtures/graphql/repoInfo.js
@@ -78,6 +78,7 @@ module.exports = {
 			vulnerabilityAlerts: {
 				nodes: [
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -94,6 +95,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: '2021-05-20T10:21:15Z',
 						securityVulnerability: {
 							severity: 'LOW',
 							advisory: {
@@ -110,6 +112,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'MODERATE',
 							advisory: {
@@ -126,6 +129,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -142,6 +146,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -158,6 +163,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -174,6 +180,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'LOW',
 							advisory: {
@@ -190,6 +197,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'LOW',
 							advisory: {
@@ -206,6 +214,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -222,6 +231,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -238,6 +248,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'HIGH',
 							advisory: {
@@ -254,6 +265,7 @@ module.exports = {
 						},
 					},
 					{
+						dismissedAt: null,
 						securityVulnerability: {
 							severity: 'CRITICAL',
 							advisory: {


### PR DESCRIPTION
Sometimes vulnerability issues are being dismissed so in the action we need to ignore dismissed vulnerability issues.

We need to add `dismissedAt` to the graphQL query and don't count the issue if the value is `null`.

https://hpinc.kanbanize.com/ctrl_board/79/cards/11687/details/