### PR TITLE
fix: don't block PRs from oneflow user

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -97,7 +97,7 @@ async function run() {
 								await action.issuesMessage(repoInfo, criticalIssues),
 						  )
 						: criticalHighIssuesFixed;
-				if (pullRequestCreator !== 'dependabot[bot]') {
+				if (!pullRequestCreator.match(/dependabot\[bot\]|oneflow/)) {
 					if (actionComment) {
 						await octokit.rest.issues.updateComment({
 							owner: repoOwner,
@@ -122,7 +122,7 @@ async function run() {
 					state: commitStatus,
 				});
 			} else {
-				if (pullRequestCreator !== 'dependabot[bot]') {
+				if (!pullRequestCreator.match(/dependabot\[bot\]|oneflow/)) {
 					const commitStatus = await action.findStatus(otherIssues, prCommits, pullRequestCreator);
 					const prMessage =
 						commitStatus === 'failure'
@@ -24653,7 +24653,7 @@ async function issuesMessage(repoInfo, vulnerabilityIssues) {
 
 async function findStatus(issuesList, prCommits, prCreator) {
 	let statuses = [];
-	if (prCreator === 'dependabot[bot]') {
+	if (prCreator.match(/dependabot\[bot\]|oneflow/)) {
 		statuses.push('success');
 	} else {
 		await issuesList.forEach((issue) => {

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ async function run() {
 								await action.issuesMessage(repoInfo, criticalIssues),
 						  )
 						: criticalHighIssuesFixed;
-				if (pullRequestCreator !== 'dependabot[bot]') {
+				if (!pullRequestCreator.match(/dependabot\[bot\]|oneflow/)) {
 					if (actionComment) {
 						await octokit.rest.issues.updateComment({
 							owner: repoOwner,
@@ -116,7 +116,7 @@ async function run() {
 					state: commitStatus,
 				});
 			} else {
-				if (pullRequestCreator !== 'dependabot[bot]') {
+				if (!pullRequestCreator.match(/dependabot\[bot\]|oneflow/)) {
 					const commitStatus = await action.findStatus(otherIssues, prCommits, pullRequestCreator);
 					const prMessage =
 						commitStatus === 'failure'

--- a/src/github/action.js
+++ b/src/github/action.js
@@ -43,7 +43,7 @@ async function issuesMessage(repoInfo, vulnerabilityIssues) {
 
 async function findStatus(issuesList, prCommits, prCreator) {
 	let statuses = [];
-	if (prCreator === 'dependabot[bot]') {
+	if (prCreator.match(/dependabot\[bot\]|oneflow/)) {
 		statuses.push('success');
 	} else {
 		await issuesList.forEach((issue) => {


### PR DESCRIPTION
Don't block PRs from the `oneflow` user.

Example https://github.com/oneflow/siteflow-analytics-ui/pull/437 